### PR TITLE
Fix build with node-gyp configure & build

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,10 @@
-mkdir lib
-cd ./libmcp23s17/ && make
-make install
+
+mkdir -p lib
+cd ./libmcp23s17/ && make && make install
 cd ..
-gcc -c -o ./lib/libpifacecad.o ./src/pifacecad.c
-ar rcs ./lib/libpifacecad.a ./lib/libpifacecad.o
+gcc -c -o ./lib/libpifacecad.o ./src/pifacecad.c \
+  && ar rcs ./lib/libpifacecad.a ./lib/libpifacecad.o
+
+node-gyp configure
+node-gyp build
+


### PR DESCRIPTION
The current install script does not build the module.
I added the missing commands to the install script.

You need node-gyp to build the module. If the command isn't already installed, you can install it with:

  npm install -g node-gyp

The install script now calls
  node-gyp configure # creates files in build directory for installed node version 
  node-gyp build     # builds the project